### PR TITLE
Cleanup for data input.

### DIFF
--- a/default_paths.py
+++ b/default_paths.py
@@ -84,6 +84,7 @@ v4 = {
   'Afregning_Underretning': ['Afregninger.xlsx', 'Sheet1'],
   'Udligning': ['Udligninger.xlsx', 'Sheet1'],
   'Udtræk': [['3977.txt', 'Test.txt', '3982.txt'], None],
+}
 
 
 if __name__ == '__main__':

--- a/default_paths.py
+++ b/default_paths.py
@@ -1,0 +1,96 @@
+# The input data format
+# ---------------------
+# 'path' is the path where all file data is assumed to be in
+# 'input' is a dictionary with information of where to find the tables:
+# 'PSRM Afregning', 'Afregning_Underretning', 'Udligning', 'Udtræk'.
+#
+# Each value in the dictornary is a list of length 2.
+# First value is a file name or a list of file names.
+# Second value is a sheet name.
+#
+# If multiple file names are given as a value then the program will concatinate 
+# the content to one table.
+#
+# Multiple Excel file or sheets are currently not implemented.
+#
+
+# The particular data locations
+# ---------------------------
+#
+# We have so far recieved updated data multiple times which we organized i 
+# version folders. Running this file as a script should test all the locations.  
+# Typical directory structure looks like this:
+#
+# Data/
+# ├── v1
+# │   ├── PSRM_CI_FT_BASE.xlsx
+# ├── v2
+# │   ├── Afregninger.xlsx
+# │   ├── CI_FT_BASE.xlsx
+# │   ├── Udligninger.xlsx
+# ├── v3
+# │   ├── Afregninger.xlsx
+# │   ├── CI_FT_BASE.xlsx
+# │   ├── Udligninger.xlsx
+# │   ├── Udtræk.xlsx
+# └── v4
+#     ├── 3977.txt
+#     ├── 3982.txt
+#     ├── Afregninger.xlsx
+#     ├── CI_FT_BASE.xlsx
+#     ├── Test.txt
+#     ├── Udligninger.xlsx
+#
+# 
+# Notes
+# ------
+#
+# 'EXTERNAL_OBLIGATION_ID' is not found in v1 of udtraeksdata
+# 
+#
+# Here are the default locations for the different locations:
+
+# first data pull-out
+path_v1 = '../Data/v1'
+v1 = {
+  'PSRM Afregning': ['PSRM_CI_FT_BASE.xlsx', 'PSRM Afregning'],
+  'Afregning_Underretning': ['PSRM_CI_FT_BASE.xlsx', 'Afregning_Underretning'],
+  'Udligning': [None, None],
+  'Udtræk': ['PSRM_CI_FT_BASE.xlsx', 'Udtræk NCO'],
+}
+
+# second data pull-out
+path_v2 = '../Data/v2'
+v2 = {
+  'PSRM Afregning': ['CI_FT_BASE.xlsx', 'Sheet1'],
+  'Afregning_Underretning': ['Afregninger.xlsx', 'Sheet1'],
+  'Udligning': ['Udligninger.xlsx', 'Sheet1'],
+  'Udtræk': [None, None],
+}
+
+# third data pull-out
+path_v3 = '../Data/v3'
+v3 = {
+  'PSRM Afregning': ['CI_FT_BASE.xlsx', 'Sheet1'],
+  'Afregning_Underretning': ['Afregninger.xlsx', 'Sheet1'],
+  'Udligning': ['Udligninger.xlsx', 'Sheet1'],
+  'Udtræk': ['Udtræk.xlsx', 'Sheet1'],
+}
+
+# third excel data + the full ACL history data from Daniel
+path_v4 = '../Data/v4'
+v4 = {
+  'PSRM Afregning': ['CI_FT_BASE.xlsx', 'Sheet1'],
+  'Afregning_Underretning': ['Afregninger.xlsx', 'Sheet1'],
+  'Udligning': ['Udligninger.xlsx', 'Sheet1'],
+  'Udtræk': [['3977.txt', 'Test.txt', '3982.txt'], None],
+
+
+if __name__ == '__main__':
+    from psrm_ci_ft_base import PSRM_CI_FT_BASE
+    psrm_v1 = PSRM_CI_FT_BASE(path=path_v1, input=v1)
+    psrm_v2 = PSRM_CI_FT_BASE(path=path_v2, input=v2)
+    psrm_v3 = PSRM_CI_FT_BASE(path=path_v3, input=v3)
+    psrm_v4 = PSRM_CI_FT_BASE(path=path_v4, input=v4)
+
+

--- a/psrm_ci_ft_base.py
+++ b/psrm_ci_ft_base.py
@@ -9,58 +9,33 @@ from udligning import Udligning
 
 class PSRM_CI_FT_BASE:
 
-    def __init__(self, path, fname='PSRM_CI_FT_BASE.xlsx', multi_sheets=None):
+    def __init__(self, path=None, input=None):
         self.path = path
-        if multi_sheets is not None:
-
-            # preset data for the second data pull-out
-#            multi_sheets = {
-#              'PSRM Afregning': ['CI_FT_BASE.xlsx', 'Sheet1'],
-#              'Afregning_Underretning': ['Afregninger.xlsx', 'Sheet1'],
-#              'Udligning': ['Udligninger.xlsx', 'Sheet1'],
-#              'Udtræk': ['Udtræk.xlsx', 'Sheet1'],
-#            }
-
-            # preset data for the 4th big ACL data from Daniel
-            multi_sheets = {
-              'PSRM Afregning': ['CI_FT_BASE.xlsx', 'Sheet1'],
-              'Afregning_Underretning': ['Afregninger.xlsx', 'Sheet1'],
-              'Udligning': ['Udligninger.xlsx', 'Sheet1'],
-              'Udtræk': [['3977.txt', 'Test.txt', '3982.txt'], None],
-            }
-
-            sheets = {}
-            for name in multi_sheets:
-                data = multi_sheets[name][0]
-                sh_name = multi_sheets[name][1]
-                if data is None:
-                    continue
-                if type(data) == str:
-                    if data.split('.')[-1] != 'xlsx':
-                        raise NotImplementedError('not a Excel file')
-                    sheet_path = os.path.join(self.path, data)
-                    sheets[name] = pd.read_excel(sheet_path, sh_name)
-                if type(data) != str:
-                    if sh_name is not None:
-                        raise NotImplementedError('multi sheets not working')
-                    dfs = []
-                    for x in data:
-                        fpath = os.path.join(self.path, x)
-                        print(fpath)
-                        if x.split('.')[-1] == 'txt':
-                            dfs.append(pd.read_csv(fpath, sep=';'))
-                        if x.split('.')[-1] == 'csv':
-                            dfs.append(pd.read_csv(fpath, sep=','))
-                    sheets[name] = pd.concat(dfs)
+        sheets = {}
+        for name in input:
+            data = input[name][0]
+            sname = input[name][1]
+            if data is None:
+                continue
+            if type(data) == str:
+                if data.split('.')[-1] != 'xlsx':
+                    raise NotImplementedError('not a Excel file')
+                sheet_path = os.path.join(self.path, data)
+                sheets[name] = pd.read_excel(sheet_path, sname)
+            if type(data) != str:
+                if sname is not None:
+                    raise NotImplementedError('multi sheets not working')
+                dfs = []
+                for x in data:
+                    fpath = os.path.join(self.path, x)
+                    if x.split('.')[-1] == 'txt':
+                        dfs.append(pd.read_csv(fpath, sep=';'))
+                    if x.split('.')[-1] == 'csv':
+                        dfs.append(pd.read_csv(fpath, sep=','))
+                sheets[name] = pd.concat(dfs)
 
             self.sheets = sheets
 
-        elif fname is not None:
-            self.fname = fname
-            self.sheets = self._read_sheets(os.path.join(self.path, self.fname))
-
-    def _read_sheets(self, fname):
-        return pd.read_excel(fname, sheet_name=None)
 
     @property
     def udligning(self):

--- a/psrm_ci_ft_base.py
+++ b/psrm_ci_ft_base.py
@@ -112,11 +112,12 @@ class PSRM_CI_FT_BASE:
 
 
 if __name__ == '__main__':
+    from default_paths import path_v4, v4
     if os.path.exists('psrm.pkl'):
         with open('psrm.pkl', 'rb') as f:
             psrm = pickle.load(f)
     else:
-        psrm = PSRM_CI_FT_BASE('../data')
+        psrm = PSRM_CI_FT_BASE(path=path_v4, input=v4)
         with open('psrm.pkl', 'wb') as f:
             pickle.dump(psrm, f)
 
@@ -124,3 +125,4 @@ if __name__ == '__main__':
         return df.sample(1).NYMFID.values[0]
 
     af, un, udl, ud = psrm.get_by_id(get_random_nymfid(psrm.afregning))
+


### PR DESCRIPTION
Long description and default path in default_paths.py.
The input data format
---------------------
'path' is the path where all file data is assumed to be in
'input' is a dictionary with information of where to find the tables:
'PSRM Afregning', 'Afregning_Underretning', 'Udligning', 'Udtræk'.

Each value in the dictornary is a list of length 2.
First value is a file name or a list of file names.
Second value is a sheet name.

If multiple file names are given as a value then the program will concatinate
the content to one table.

Multiple Excel file or sheets are currently not implemented.


The particular data locations
---------------------------

We have so far recieved updated data multiple times which we organized i
version folders. Running this file as a script should test all the locations.
Typical directory structure looks like this:

Data/
├── v1
│   ├── PSRM_CI_FT_BASE.xlsx
├── v2
│   ├── Afregninger.xlsx
│   ├── CI_FT_BASE.xlsx
│   ├── Udligninger.xlsx
├── v3
│   ├── Afregninger.xlsx
│   ├── CI_FT_BASE.xlsx
│   ├── Udligninger.xlsx
│   ├── Udtræk.xlsx
├── v4
│      ├── 3977.txt
│      ├── 3982.txt
│    ├── Afregninger.xlsx
│    ├── CI_FT_BASE.xlsx
│    ├── Test.txt
│    ├── Udligninger.xlsx


Notes
------

'EXTERNAL_OBLIGATION_ID' is not found in v1 of udtraeksdata
