### PR TITLE
Find a target sum in combinations of a list of numbers

### DIFF
--- a/psrm/utils/number_util.py
+++ b/psrm/utils/number_util.py
@@ -1,0 +1,28 @@
+from itertools import combinations
+
+
+def find_target_sum(target, numbers, nmax=5):
+    """Find the target sum in all combinations of a list.
+
+    Input
+    -----
+    target: float
+      The target sum
+    numbers: list
+      List of floats, e.g. IR
+    nmax: int (default is 5)
+      The max length of the list of combinations. E.g. if 3, then
+      the list of combinations will have length of 1, 2, and 3.
+
+    Output
+    ------
+    res: list
+      The list of combinations which sum gives the target sum
+    """
+    if target in numbers:
+        return [target]
+
+    for r in range(2, nmax+1):  # [2, 3, ..., namx]
+        for combination in combinations(numbers, r):
+            if sum(combination) == target:
+                return list(combination)

--- a/psrm/utils/number_util.py
+++ b/psrm/utils/number_util.py
@@ -26,3 +26,8 @@ def find_target_sum(target, numbers, nmax=5):
         for combination in combinations(numbers, r):
             if sum(combination) == target:
                 return list(combination)
+
+
+def count_occurences(numbers):
+    numbers = list(numbers)
+    return {number: numbers.count(number) for number in set(numbers)}


### PR DESCRIPTION
Kan bruges til at finde en diff i e.g. DR og PSRM er sket pga. glemte IR.
```python
fing_target_sum(diff, interests, nmax=6)
```
vil finde en kombination fra `interests` hvis sum er lig `diff` og retunere denne kombination som en liste. Ellers retuneres `None`.